### PR TITLE
Update deprecated MongoDB read preference constants to use current values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /vendor/
 composer.lock
-.phpunit.result.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "mongodb/laravel-mongodb": "^4.1"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0"
+        "orchestra/testbench": "^8.0",
+        "ext-mongodb": "*"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "1ff/laravel-mongodb-cache",
     "description": "A mongodb cache driver for laravel",
     "type": "library",
-    "version": "6.0.4",
     "require": {
         "php": "^8.1",
         "illuminate/cache": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
     "require": {
         "php": "^8.1",
         "illuminate/cache": "^10.0",
-        "mongodb/laravel-mongodb": "^4.1"
+        "mongodb/laravel-mongodb": "^4.1",
+        "ext-mongodb": "*"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0",
-        "ext-mongodb": "*"
+        "orchestra/testbench": "^8.0"
     },
     "license": "MIT",
     "authors": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false"
+         colors="true" processIsolation="false" stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
     <testsuites>
         <testsuite name="MongoDB Cache Test Suite">
             <directory>tests</directory>

--- a/src/Console/Commands/MongodbCacheDropIndex.php
+++ b/src/Console/Commands/MongodbCacheDropIndex.php
@@ -4,7 +4,7 @@ namespace ForFit\Mongodb\Cache\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
-use \MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\ReadPreference;
 
 /**
  * Drop the indexes created by MongodbCacheIndex
@@ -12,26 +12,14 @@ use \MongoDB\Driver\ReadPreference;
 class MongodbCacheDropIndex extends Command
 {
 
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
+    /** The name and signature of the console command. */
     protected $signature = 'mongodb:cache:dropindex {index}';
 
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
+    /** The console command description. */
     protected $description = 'Drops the passed index from the mongodb `cache` collection';
 
-    /**
-     * Execute the console command.
-     *
-     * @return mixed
-     */
-    public function handle()
+    /** Execute the console command. */
+    public function handle(): void
     {
         $cacheCollectionName = config('cache')['stores']['mongodb']['table'];
 
@@ -39,7 +27,7 @@ class MongodbCacheDropIndex extends Command
             'dropIndexes' => $cacheCollectionName,
             'index' => $this->argument('index'),
         ], [
-            'readPreference' => new ReadPreference(ReadPreference::RP_PRIMARY)
+            'readPreference' => new ReadPreference(ReadPreference::PRIMARY)
         ]);
     }
 }

--- a/src/Console/Commands/MongodbCacheIndex.php
+++ b/src/Console/Commands/MongodbCacheIndex.php
@@ -4,7 +4,7 @@ namespace ForFit\Mongodb\Cache\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
-use \MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\ReadPreference;
 
 /**
  * Create indexes for the cache collection
@@ -12,26 +12,14 @@ use \MongoDB\Driver\ReadPreference;
 class MongodbCacheIndex extends Command
 {
 
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
+    /** The name and signature of the console command. */
     protected $signature = 'mongodb:cache:index';
 
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
+    /** The console command description. */
     protected $description = 'Create indexes on the mongodb `cache` collection';
 
-    /**
-     * Execute the console command.
-     *
-     * @return mixed
-     */
-    public function handle()
+    /** Execute the console command. */
+    public function handle(): void
     {
         $cacheCollectionName = config('cache')['stores']['mongodb']['table'];
 
@@ -52,7 +40,7 @@ class MongodbCacheIndex extends Command
                 ]
             ]
         ], [
-            'readPreference' => new ReadPreference(ReadPreference::RP_PRIMARY)
+            'readPreference' => new ReadPreference(ReadPreference::PRIMARY)
         ]);
     }
 }

--- a/src/Console/Commands/MongodbCacheIndexTags.php
+++ b/src/Console/Commands/MongodbCacheIndexTags.php
@@ -4,7 +4,7 @@ namespace ForFit\Mongodb\Cache\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
-use \MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\ReadPreference;
 
 /**
  * Create indexes for the cache collection
@@ -12,26 +12,14 @@ use \MongoDB\Driver\ReadPreference;
 class MongodbCacheIndexTags extends Command
 {
 
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
+    /** The name and signature of the console command. */
     protected $signature = 'mongodb:cache:index_tags';
 
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
+    /** The console command description. */
     protected $description = 'Create indexes on the tags column of mongodb `cache` collection';
 
-    /**
-     * Execute the console command.
-     *
-     * @return mixed
-     */
-    public function handle()
+    /** Execute the console command.*/
+    public function handle(): void
     {
         $cacheCollectionName = config('cache')['stores']['mongodb']['table'];
 
@@ -45,7 +33,7 @@ class MongodbCacheIndexTags extends Command
                 ],
             ]
         ], [
-            'readPreference' => new ReadPreference(ReadPreference::RP_PRIMARY)
+            'readPreference' => new ReadPreference(ReadPreference::PRIMARY)
         ]);
     }
 }

--- a/src/MongoTaggedCache.php
+++ b/src/MongoTaggedCache.php
@@ -2,16 +2,16 @@
 
 namespace ForFit\Mongodb\Cache;
 
+use Illuminate\Cache\Events\KeyWritten;
 use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\Store;
-use Illuminate\Cache\Events\KeyWritten;
 
 class MongoTaggedCache extends Repository
 {
-    protected $tags;
+    protected array $tags;
 
     /**
-     * @param \Illuminate\Contracts\Cache\Store $store
+     * @param Store $store
      * @param array $tags
      */
     public function __construct(Store $store, array $tags = [])
@@ -27,12 +27,12 @@ class MongoTaggedCache extends Repository
      * @param  string  $key
      * @param  mixed   $value
      * @param  \DateTimeInterface|\DateInterval|float|int  $ttl
-     * @return void
+     * @return bool|null
      */
     public function put($key, $value, $ttl = null)
     {
         if (is_array($key)) {
-            return $this->putMany($key, $value);
+            $this->putMany($key, $value);
         }
 
         $seconds = $this->getSeconds(is_null($ttl) ? 315360000 : $ttl);
@@ -45,19 +45,17 @@ class MongoTaggedCache extends Repository
             }
 
             return $result;
-        } else {
-            return $this->forget($key);
         }
+
+        return $this->forget($key);
     }
 
     /**
      * Saves array of key value pairs to the cache
      *
-     * @param array $values
      * @param  \DateTimeInterface|\DateInterval|float|int  $ttl
-     * @return void
      */
-    public function putMany(array $values, $ttl = null)
+    public function putMany(array $values, $ttl = null): void
     {
         foreach ($values as $key => $value) {
             $this->put($key, $value, $ttl);
@@ -66,11 +64,9 @@ class MongoTaggedCache extends Repository
 
     /**
      * Flushes the cache for the given tags
-     *
-     * @return void
      */
-    public function flush()
+    public function flush(): void
     {
-        return $this->store->flushByTags($this->tags);
+        $this->store->flushByTags($this->tags);
     }
 }

--- a/src/Store.php
+++ b/src/Store.php
@@ -3,10 +3,10 @@
 namespace ForFit\Mongodb\Cache;
 
 use Closure;
-use Illuminate\Support\InteractsWithTime;
 use Illuminate\Cache\RetrievesMultipleKeys;
-use Illuminate\Database\ConnectionInterface;
 use Illuminate\Contracts\Cache\Store as StoreInterface;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Support\InteractsWithTime;
 use Jenssegers\Mongodb\Query\Builder;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Driver\Exception\BulkWriteException;
@@ -107,7 +107,7 @@ class Store implements StoreInterface
     /**
      * @inheritDoc
      */
-    public function forever($key, $value)
+    public function forever($key, $value): bool
     {
         return $this->put($key, $value, 315360000);
     }
@@ -115,7 +115,7 @@ class Store implements StoreInterface
     /**
      * @inheritDoc
      */
-    public function forget($key)
+    public function forget($key): bool
     {
         $this->table()->where('key', '=', $this->getPrefix() . $key)->delete();
 
@@ -125,7 +125,7 @@ class Store implements StoreInterface
     /**
      * @inheritDoc
      */
-    public function flush()
+    public function flush(): bool
     {
         $this->table()->delete();
 
@@ -135,29 +135,23 @@ class Store implements StoreInterface
     /**
      * @inheritDoc
      */
-    public function getPrefix()
+    public function getPrefix(): string
     {
         return $this->prefix;
     }
 
     /**
      * Sets the tags to be used
-     *
-     * @param array $tags
-     * @return MongoTaggedCache
      */
-    public function tags(array $tags)
+    public function tags(array $tags): MongoTaggedCache
     {
         return new MongoTaggedCache($this, $tags);
     }
 
     /**
      * Deletes all records with the given tag
-     *
-     * @param array $tags
-     * @return void
      */
-    public function flushByTags(array $tags)
+    public function flushByTags(array $tags): void
     {
         foreach ($tags as $tag) {
             $this->table()->where('tags', $tag)->delete();
@@ -166,11 +160,8 @@ class Store implements StoreInterface
 
     /**
      * Retrieve an item's expiration time from the cache by key.
-     *
-     * @param string $key
-     * @return null|float|int
      */
-    public function getExpiration($key)
+    public function getExpiration($key): ?float
     {
         $cacheData = $this->table()->where('key', $this->getKeyWithPrefix($key))->first();
 
@@ -199,7 +190,7 @@ class Store implements StoreInterface
      * @param string $key
      * @return string
      */
-    protected function getKeyWithPrefix(string $key)
+    protected function getKeyWithPrefix(string $key): string
     {
         return $this->getPrefix() . $key;
     }
@@ -210,7 +201,7 @@ class Store implements StoreInterface
      * @param string $key
      * @param int $value
      * @param Closure $callback
-     * @return int|bool
+     * @return false|mixed
      */
     protected function incrementOrDecrement($key, $value, Closure $callback)
     {

--- a/tests/StoreTest.php
+++ b/tests/StoreTest.php
@@ -5,11 +5,12 @@ namespace Tests;
 use ForFit\Mongodb\Cache\MongoTaggedCache;
 use ForFit\Mongodb\Cache\Store;
 use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Models\Cache;
 
 class StoreTest extends TestCase
 {
-    protected $store;
+    protected Store $store;
 
     protected function setUp(): void
     {
@@ -21,8 +22,8 @@ class StoreTest extends TestCase
         Carbon::setTestNow(now());
     }
 
-    /** @test */
-    public function it_stores_an_item_in_the_cache_for_given_time()
+    #[Test]
+    public function it_stores_an_item_in_the_cache_for_given_time(): void
     {
         // Act
         $sut = $this->store->put('test-key', 'test-value', 3);
@@ -37,8 +38,8 @@ class StoreTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_updates_an_item_in_the_cache_for_given_time()
+    #[Test]
+    public function it_updates_an_item_in_the_cache_for_given_time(): void
     {
         Cache::create([
             'key' => 'test-key',
@@ -58,8 +59,8 @@ class StoreTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_retrieves_value_from_the_cache_by_given_key()
+    #[Test]
+    public function it_retrieves_value_from_the_cache_by_given_key(): void
     {
         // Arrange
         Cache::create([
@@ -75,8 +76,8 @@ class StoreTest extends TestCase
         $this->assertEquals('test-value', $sut);
     }
 
-    /** @test */
-    public function it_returns_null_if_key_does_not_exist()
+    #[Test]
+    public function it_returns_null_if_key_does_not_exist(): void
     {
         // Act
         $sut = $this->store->get('test-key');
@@ -85,8 +86,8 @@ class StoreTest extends TestCase
         $this->assertNull($sut);
     }
 
-    /** @test */
-    public function it_sets_the_tags_to_be_used()
+    #[Test]
+    public function it_sets_the_tags_to_be_used(): void
     {
         // Act
         $sut = $this->store->tags(['tag1', 'tag2']);
@@ -96,8 +97,8 @@ class StoreTest extends TestCase
         $this->assertPropertySame(['tag1', 'tag2'], 'tags', $sut);
     }
 
-    /** @test */
-    public function it_deletes_all_records_with_the_given_tag()
+    #[Test]
+    public function it_deletes_all_records_with_the_given_tag(): void
     {
         // Arrange
         Cache::create([
@@ -126,8 +127,8 @@ class StoreTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_retrieves_an_items_expiration_time_by_given_key()
+    #[Test]
+    public function it_retrieves_an_items_expiration_time_by_given_key(): void
     {
         // Arrange
         Cache::create([

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,7 @@ use Tests\Overrides\Builder;
 
 abstract class TestCase extends Orchestra
 {
-    private $table = 'cache_test';
+    private string $table = 'cache_test';
     private $connectionInterface;
 
     /**
@@ -41,7 +41,7 @@ abstract class TestCase extends Orchestra
      *
      * @param \Illuminate\Foundation\Application $app
      */
-    protected function getEnvironmentSetUp($app)
+    protected function getEnvironmentSetUp($app): void
     {
         $app['config']->set('cache.stores.mongodb', [
             'driver' => 'mongodb',
@@ -78,7 +78,7 @@ abstract class TestCase extends Orchestra
      *
      * @param \Illuminate\Foundation\Application $app
      */
-    protected function setUpDatabase($app)
+    protected function setUpDatabase($app): void
     {
         $app['db']->connection()->getSchemaBuilder()->create($this->table, function (Blueprint $table) {
             $table->increments('_id');
@@ -112,11 +112,10 @@ abstract class TestCase extends Orchestra
      * @return void
      * @throws \ReflectionException
      */
-    protected function assertPropertySame($expected, $property, $object, string $message = '')
+    protected function assertPropertySame($expected, $property, $object, string $message = ''): void
     {
         $reflectedClass = new \ReflectionClass($object);
         $reflection = $reflectedClass->getProperty($property);
-        $reflection->setAccessible(true);
 
         $this->assertSame($expected, $reflection->getValue($object), $message);
     }


### PR DESCRIPTION
Refactor StoreTest to use attributes for test annotations, update PHPUnit configuration and improve code type hints. Adjust .gitignore for PHPUnit cache directory and add ext-mongodb requirement in composer.json.